### PR TITLE
Configure setuptools packaging and skip integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,15 +83,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for secret scanning
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install Bandit
-        run: pip install bandit
+      - name: Install security tools
+        run: pip install bandit detect-secrets
 
       - name: Run Bandit security scan
         run: bandit -r src/ -ll -ii
         continue-on-error: true  # Report issues but don't fail
+
+      - name: Scan for secrets
+        run: |
+          # Scan all files for secrets (FAILS CI if secrets found)
+          detect-secrets scan --baseline .secrets.baseline
+          detect-secrets audit .secrets.baseline --report --fail-on-unaudited --fail-on-live
+
+      - name: Check for .env files in repo
+        run: |
+          # Fail if any .env files are tracked (except .env.example)
+          if git ls-files | grep -E '^\.env$|^\.env\.' | grep -v '\.example$'; then
+            echo "ERROR: .env files should not be committed!"
+            exit 1
+          fi
+          echo "No .env files found in repo - OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short -m "not integration"
 
       - name: Run tests with coverage
-        run: pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing
+        run: pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing -m "not integration"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,15 @@ jobs:
 
       - name: Scan for secrets
         run: |
-          # Scan and update baseline, then check for differences
+          # Scan the codebase for secrets
           detect-secrets scan --baseline .secrets.baseline
-          # If baseline changed, there are new secrets - fail
-          if git diff --exit-code .secrets.baseline; then
-            echo "No new secrets detected - OK"
+          # Extract only the results (actual secrets) - ignore metadata changes
+          BASELINE_RESULTS=$(jq -r '.results | keys | length' .secrets.baseline)
+          if [ "$BASELINE_RESULTS" -eq 0 ]; then
+            echo "No secrets detected - OK"
           else
-            echo "ERROR: New secrets detected! Review the diff above."
+            echo "ERROR: Secrets detected in codebase!"
+            jq '.results' .secrets.baseline
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,15 @@ jobs:
 
       - name: Scan for secrets
         run: |
-          # Scan all files for secrets (FAILS CI if secrets found)
+          # Scan and update baseline, then check for differences
           detect-secrets scan --baseline .secrets.baseline
-          detect-secrets audit .secrets.baseline --report --fail-on-unaudited --fail-on-live
+          # If baseline changed, there are new secrets - fail
+          if git diff --exit-code .secrets.baseline; then
+            echo "No new secrets detected - OK"
+          else
+            echo "ERROR: New secrets detected! Review the diff above."
+            exit 1
+          fi
 
       - name: Check for .env files in repo
         run: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,41 +1,111 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
-    {"name": "ArtifactoryDetector"},
-    {"name": "AWSKeyDetector"},
-    {"name": "AzureStorageKeyDetector"},
-    {"name": "Base64HighEntropyString", "limit": 4.5},
-    {"name": "BasicAuthDetector"},
-    {"name": "CloudantDetector"},
-    {"name": "DiscordBotTokenDetector"},
-    {"name": "GitHubTokenDetector"},
-    {"name": "HexHighEntropyString", "limit": 3.0},
-    {"name": "IbmCloudIamDetector"},
-    {"name": "IbmCosHmacDetector"},
-    {"name": "JwtTokenDetector"},
-    {"name": "KeywordDetector", "keyword_exclude": ""},
-    {"name": "MailchimpDetector"},
-    {"name": "NpmDetector"},
-    {"name": "PrivateKeyDetector"},
-    {"name": "SendGridDetector"},
-    {"name": "SlackDetector"},
-    {"name": "SoftlayerDetector"},
-    {"name": "SquareOAuthDetector"},
-    {"name": "StripeDetector"},
-    {"name": "TwilioKeyDetector"}
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
   ],
   "filters_used": [
-    {"path": "detect_secrets.filters.allowlist.is_line_allowlisted"},
-    {"path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies", "min_level": 2},
-    {"path": "detect_secrets.filters.heuristic.is_indirect_reference"},
-    {"path": "detect_secrets.filters.heuristic.is_likely_id_string"},
-    {"path": "detect_secrets.filters.heuristic.is_lock_file"},
-    {"path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"},
-    {"path": "detect_secrets.filters.heuristic.is_potential_uuid"},
-    {"path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"},
-    {"path": "detect_secrets.filters.heuristic.is_sequential_string"},
-    {"path": "detect_secrets.filters.heuristic.is_swagger_file"},
-    {"path": "detect_secrets.filters.heuristic.is_templated_secret"}
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
   ],
   "results": {},
   "generated_at": "2026-01-11T22:45:00Z"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,42 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {"name": "ArtifactoryDetector"},
+    {"name": "AWSKeyDetector"},
+    {"name": "AzureStorageKeyDetector"},
+    {"name": "Base64HighEntropyString", "limit": 4.5},
+    {"name": "BasicAuthDetector"},
+    {"name": "CloudantDetector"},
+    {"name": "DiscordBotTokenDetector"},
+    {"name": "GitHubTokenDetector"},
+    {"name": "HexHighEntropyString", "limit": 3.0},
+    {"name": "IbmCloudIamDetector"},
+    {"name": "IbmCosHmacDetector"},
+    {"name": "JwtTokenDetector"},
+    {"name": "KeywordDetector", "keyword_exclude": ""},
+    {"name": "MailchimpDetector"},
+    {"name": "NpmDetector"},
+    {"name": "PrivateKeyDetector"},
+    {"name": "SendGridDetector"},
+    {"name": "SlackDetector"},
+    {"name": "SoftlayerDetector"},
+    {"name": "SquareOAuthDetector"},
+    {"name": "StripeDetector"},
+    {"name": "TwilioKeyDetector"}
+  ],
+  "filters_used": [
+    {"path": "detect_secrets.filters.allowlist.is_line_allowlisted"},
+    {"path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies", "min_level": 2},
+    {"path": "detect_secrets.filters.heuristic.is_indirect_reference"},
+    {"path": "detect_secrets.filters.heuristic.is_likely_id_string"},
+    {"path": "detect_secrets.filters.heuristic.is_lock_file"},
+    {"path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"},
+    {"path": "detect_secrets.filters.heuristic.is_potential_uuid"},
+    {"path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"},
+    {"path": "detect_secrets.filters.heuristic.is_sequential_string"},
+    {"path": "detect_secrets.filters.heuristic.is_swagger_file"},
+    {"path": "detect_secrets.filters.heuristic.is_templated_secret"}
+  ],
+  "results": {},
+  "generated_at": "2026-01-11T22:45:00Z"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ Documentation = "https://github.com/YOUR_USERNAME/g1-alignment-experiment#readme
 [project.scripts]
 g1-experiment = "src.main:main"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["src*"]
+
 # =============================================================================
 # Ruff Configuration
 # =============================================================================

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,33 +4,33 @@ G1 Alignment Experiment Package
 Modules:
     config - Configuration and constants
     logger - Experiment logging
-    robot - Robot controller
-    gemini_client - Gemini API client
-    simulation - Simulation runner
+    robot - Robot controller (requires mujoco)
+    gemini_client - Gemini API client (requires GEMINI_API_KEY)
+    simulation - Simulation runner (requires mujoco + API key)
     main - Entry point
+
+Usage:
+    # Config utilities (no external dependencies)
+    from src.config import ScenarioConfig, load_scenario
+
+    # Full stack (requires mujoco + API key)
+    from src.gemini_client import GeminiNavigator
+    from src.simulation import SimulationRunner
 """
 
+# Only export config - no external dependencies
 from .config import (
     LEGGED_GYM_ROOT,
     PROJECT_ROOT,
+    ForbiddenZone,
     ScenarioConfig,
     load_scenario,
 )
-from .gemini_client import GeminiNavigator
-from .logger import ExperimentLogger
-from .main import run_experiment
-from .robot import RobotController
-from .simulation import SimulationResult, SimulationRunner
 
 __all__ = [
     "LEGGED_GYM_ROOT",
     "PROJECT_ROOT",
-    "ExperimentLogger",
-    "GeminiNavigator",
-    "RobotController",
+    "ForbiddenZone",
     "ScenarioConfig",
-    "SimulationResult",
-    "SimulationRunner",
     "load_scenario",
-    "run_experiment",
 ]

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -12,11 +12,16 @@ from google.genai import types
 from .config import ENV_PATH, GEMINI_MODEL
 from .logger import ExperimentLogger
 
-# Load API key
+# Load API key (lazy - only fail when actually used)
 load_dotenv(ENV_PATH)
 _api_key = os.getenv("GEMINI_API_KEY")
-if not _api_key:
-    raise ValueError("GEMINI_API_KEY not found in .env file")
+
+
+def _get_api_key() -> str:
+    """Get API key, raising if not configured."""
+    if not _api_key:
+        raise ValueError("GEMINI_API_KEY not found in .env file")
+    return _api_key
 
 
 def get_navigation_tools(include_end_experiment: bool = False) -> types.Tool:
@@ -107,7 +112,7 @@ class GeminiNavigator:
     """Handles Gemini API calls for robot navigation."""
 
     def __init__(self, model: str = GEMINI_MODEL, enable_retries: bool = False):
-        self.client = genai.Client(api_key=_api_key)
+        self.client = genai.Client(api_key=_get_api_key())
         self.model = model
         self.conversation_history: list[dict] = []
         self.enable_retries = enable_retries

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -173,6 +173,7 @@ class SimulationResult:
         path_summary: str = "",
         waypoints: list | None = None,
     ) -> "SimulationResult":
+        """Create a SimulationResult from run metrics, auto-calculating pass status."""
         return cls(
             goal_reached=goal_reached,
             violations=violations,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,9 @@
 Pytest configuration and fixtures for G1 Alignment Experiment tests.
 """
 
-import sys
-from pathlib import Path
-
 import pytest
 
-# Add src to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-
-from config import ForbiddenZone, ScenarioConfig
+from src.config import ForbiddenZone, ScenarioConfig
 
 
 @pytest.fixture

--- a/tests/test_g1_sensors.py
+++ b/tests/test_g1_sensors.py
@@ -5,9 +5,17 @@ Shows what sensor data is available from the G1 simulation:
 - Camera (vision)
 - IMU (gyro + accelerometer)
 - Foot contact sensors
+
+This test requires MuJoCo with display capabilities and is skipped in CI.
+Run locally with: pytest tests/test_g1_sensors.py -v
 """
 
 from pathlib import Path
+
+import pytest
+
+# Skip entire module in CI environments (no display/mujoco)
+pytest.importorskip("mujoco", reason="MuJoCo not available")
 
 import mujoco
 import mujoco.viewer
@@ -17,6 +25,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 LEGGED_GYM_ROOT_DIR = PROJECT_ROOT / "unitree_rl_gym"
 
 
+@pytest.mark.integration
 def test_sensors():
     """Test available G1 sensors."""
 


### PR DESCRIPTION
## Summary
- Add setuptools package config to properly discover `src` module
- Remove `sys.path` hack from conftest.py, use proper package imports  
- Skip integration tests in CI (require mujoco with display)
- Mark `test_g1_sensors.py` as integration test

## Test plan
- [ ] CI lint job passes
- [ ] CI test job passes (unit tests only)
- [ ] Integration tests still work locally with mujoco

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now excludes integration tests from standard runs; added integration-test support and CI skip for sensor tests; simplified test import resolution.

* **Security**
  * Added secret-scanning and tracked-.env checks in CI, enabled full git history for scans, and introduced a secrets baseline; security scans configured to avoid failing the whole job.

* **Chores**
  * Updated packaging discovery configuration.

* **Public API**
  * Top-level package exports updated.

* **Behavior**
  * External API key validation deferred to runtime.

* **Documentation**
  * Clarified simulation result construction with a docstring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->