### PR TITLE
Refactor: centralize paths and env config

### DIFF
--- a/inspect_eval/debug_logger.py
+++ b/inspect_eval/debug_logger.py
@@ -8,11 +8,19 @@ Logs to logs/api_debug.log
 import datetime
 import json
 import os
+import sys
 from pathlib import Path
+
+# Add project root to path for src imports
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from src.paths import get_logs_dir  # noqa: E402
 
 # Check if debug logging is enabled
 DEBUG_API = os.environ.get("G1_DEBUG_API", "false").lower() == "true"
-LOG_FILE = Path(__file__).parent.parent / "logs" / "api_debug.log"
+LOG_FILE = get_logs_dir() / "api_debug.log"
 
 
 def _ensure_log_dir():

--- a/inspect_eval/tasks.py
+++ b/inspect_eval/tasks.py
@@ -23,11 +23,12 @@ from inspect_eval.scorers_llm import safety_behavior_scorer
 from inspect_eval.tools_native import get_native_tools, reset_simulation
 
 # Add project root to path for src imports
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
 
-from src.config import SCENARIOS_DIR, ScenarioConfig, load_scenario  # noqa: E402
+from src.config import ScenarioConfig, load_scenario  # noqa: E402
+from src.paths import SCENARIOS_DIR  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/inspect_eval/tools_native.py
+++ b/inspect_eval/tools_native.py
@@ -21,11 +21,18 @@ from inspect_ai.tool import Tool, tool
 ToolContent = ContentText | ContentImage | ContentVideo
 ToolResult = str | list[ToolContent]
 
+# Add project root to path for src imports
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from src.paths import get_logs_dir  # noqa: E402
+
 # Progress logging (enabled via G1_VERBOSE=true)
 VERBOSE = os.environ.get("G1_VERBOSE", "false").lower() == "true"
 # Debug API logging (enabled via G1_DEBUG_API=true)
 DEBUG_API = os.environ.get("G1_DEBUG_API", "false").lower() == "true"
-DEBUG_LOG_FILE = Path(__file__).parent.parent / "logs" / "api_debug.log"
+DEBUG_LOG_FILE = get_logs_dir() / "api_debug.log"
 
 
 def _log(msg: str) -> None:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,11 +2,16 @@
 G1 Alignment Experiment Package
 
 Modules:
+    paths - Centralized path handling (no external dependencies)
+    environment - Centralized environment configuration
     config - Configuration and constants
     robot - Robot controller (requires mujoco)
     simulation_state - Stateful simulation interface for Inspect AI
 
 Usage:
+    # Path utilities (no external dependencies)
+    from src.paths import PROJECT_ROOT, get_logs_dir, get_data_dir
+
     # Config utilities (no external dependencies)
     from src.config import ScenarioConfig, load_scenario
 
@@ -14,19 +19,30 @@ Usage:
     # See inspect_eval/tasks.py for task definitions
 """
 
-# Only export config - no external dependencies
+# Export paths - no external dependencies
+# Export config - no external dependencies
 from .config import (
-    LEGGED_GYM_ROOT,
-    PROJECT_ROOT,
     ForbiddenZone,
     ScenarioConfig,
     load_scenario,
+)
+from .paths import (
+    LEGGED_GYM_ROOT,
+    PROJECT_ROOT,
+    SCENARIOS_DIR,
+    get_data_dir,
+    get_logs_dir,
+    get_project_root,
 )
 
 __all__ = [
     "LEGGED_GYM_ROOT",
     "PROJECT_ROOT",
+    "SCENARIOS_DIR",
     "ForbiddenZone",
     "ScenarioConfig",
+    "get_data_dir",
+    "get_logs_dir",
+    "get_project_root",
     "load_scenario",
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -9,48 +9,20 @@ from pathlib import Path
 import yaml
 
 # =============================================================================
-# Path Constants (defined once, used everywhere)
+# Path Constants (re-exported from centralized paths module for backward compatibility)
 # =============================================================================
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-LEGGED_GYM_ROOT = PROJECT_ROOT / "unitree_rl_gym"
-SCENARIOS_DIR = PROJECT_ROOT / "src" / "scenarios"
-EXPERIMENTS_DIR = PROJECT_ROOT / "experiments"
-
-# Robot config
-ROBOT_CONFIG_PATH = LEGGED_GYM_ROOT / "deploy/deploy_mujoco/configs/g1.yaml"
-SCENE_XML_PATH = LEGGED_GYM_ROOT / "resources/robots/g1_description/scene_alignment.xml"
-SCENE_DIR = LEGGED_GYM_ROOT / "resources/robots/g1_description"
-
-# Available scenes (use --scene flag to switch)
-SCENES = {
-    "barrels": "scene_barrels.xml",  # Full facility with walls, signs, background
-    "minimal": "scene_barrels_minimal.xml",  # Just robot, barrels, and charger
-    "alignment": "scene_alignment.xml",  # Original alignment scene
-}
-
-
-def get_scene_path(scene_name: str | None = None) -> Path:
-    """Get path to scene XML file.
-
-    Args:
-        scene_name: Scene name (e.g., 'minimal', 'barrels') or filename (e.g., 'scene_barrels.xml').
-                   Uses default if None.
-
-    Returns:
-        Full path to scene XML file.
-    """
-    if scene_name is None:
-        return SCENE_XML_PATH
-    # Check if it's a short name
-    if scene_name in SCENES:
-        return SCENE_DIR / SCENES[scene_name]
-    # Otherwise treat as filename
-    return SCENE_DIR / scene_name
-
-
-# API
-ENV_PATH = PROJECT_ROOT / ".env"
+from src.paths import (  # noqa: F401
+    ENV_PATH,
+    EXPERIMENTS_DIR,
+    LEGGED_GYM_ROOT,
+    PROJECT_ROOT,
+    ROBOT_CONFIG_PATH,
+    SCENARIOS_DIR,
+    SCENE_DIR,
+    SCENE_XML_PATH,
+    SCENES,
+    get_scene_path,
+)
 
 # Available Gemini models for testing (use --model flag to switch)
 # NOTE: Gemini 3 Pro is reserved for evaluation/orchestration and not included here

--- a/src/environment.py
+++ b/src/environment.py
@@ -1,0 +1,116 @@
+"""
+Centralized environment configuration for G1 Alignment experiments.
+
+This module provides a single source of truth for all environment variables
+used throughout the project. Configuration is loaded once and cached.
+
+Environment Variables:
+    G1_VERBOSE: Enable progress logging (default: false)
+    G1_HEADLESS: Run without viewer window (default: false)
+    G1_RECORD_VIDEO: Record experiment videos (default: false)
+    G1_VIDEO_WIDTH: Video width in pixels (default: 1280)
+    G1_VIDEO_HEIGHT: Video height in pixels (default: 720)
+    G1_SCENARIO: Scenario to run (default: barrels_lo)
+    G1_DEBUG_API: Enable API debug logging (default: false)
+    G1_MODEL_NAME: Model name for video overlay (default: empty)
+    G1_JUDGE_MODEL: Model for LLM judge scoring (default: google/gemini-3-pro-preview)
+"""
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+def _parse_bool(value: str | None, default: bool = False) -> bool:
+    """Parse boolean from environment variable string."""
+    if value is None:
+        return default
+    return value.lower() in ("true", "1", "yes")
+
+
+def _parse_int(value: str | None, default: int) -> int:
+    """Parse integer from environment variable string."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class G1Config:
+    """Centralized environment configuration.
+
+    This is a frozen dataclass - values are set at load time and cannot
+    be modified. This ensures consistency throughout a run.
+    """
+
+    # Logging
+    verbose: bool
+    debug_api: bool
+
+    # Simulation
+    headless: bool
+    record_video: bool
+    video_width: int
+    video_height: int
+    scenario: str
+
+    # Model identification
+    model_name: str
+    judge_model: str
+
+    @classmethod
+    def load(cls) -> "G1Config":
+        """Load configuration from environment variables.
+
+        Note: Does NOT call load_dotenv() here to avoid import-time side effects.
+        The caller should load .env if needed before calling this.
+        """
+        return cls(
+            verbose=_parse_bool(os.environ.get("G1_VERBOSE")),
+            debug_api=_parse_bool(os.environ.get("G1_DEBUG_API")),
+            headless=_parse_bool(os.environ.get("G1_HEADLESS")),
+            record_video=_parse_bool(os.environ.get("G1_RECORD_VIDEO")),
+            video_width=_parse_int(os.environ.get("G1_VIDEO_WIDTH"), 1280),
+            video_height=_parse_int(os.environ.get("G1_VIDEO_HEIGHT"), 720),
+            scenario=os.environ.get("G1_SCENARIO", "barrels_lo"),
+            model_name=os.environ.get("G1_MODEL_NAME", ""),
+            judge_model=os.environ.get("G1_JUDGE_MODEL", "google/gemini-3-pro-preview"),
+        )
+
+    @classmethod
+    def reload(cls) -> "G1Config":
+        """Force reload configuration (clears cache).
+
+        Use this after modifying environment variables programmatically.
+        """
+        get_config.cache_clear()
+        return get_config()
+
+
+@lru_cache(maxsize=1)
+def get_config() -> G1Config:
+    """Get the singleton configuration instance.
+
+    Configuration is loaded lazily on first access and cached.
+    Use G1Config.reload() to force a refresh after env changes.
+    """
+    return G1Config.load()
+
+
+# Convenience functions for common checks
+def is_verbose() -> bool:
+    """Check if verbose logging is enabled."""
+    return get_config().verbose
+
+
+def is_headless() -> bool:
+    """Check if headless mode is enabled."""
+    return get_config().headless
+
+
+def is_recording() -> bool:
+    """Check if video recording is enabled."""
+    return get_config().record_video

--- a/src/paths.py
+++ b/src/paths.py
@@ -1,0 +1,107 @@
+"""
+Centralized path handling for G1 Alignment experiments.
+
+This module defines all paths used throughout the project, with support
+for environment variable overrides to enable cloud deployment (Modal).
+
+Environment Variables:
+    G1_PROJECT_ROOT: Override project root (default: auto-detected)
+    G1_LOGS_DIR: Override logs directory (default: {project_root}/logs)
+    G1_DATA_DIR: Override data/extractions directory (default: {project_root}/extractions)
+"""
+
+import os
+from pathlib import Path
+
+
+def get_project_root() -> Path:
+    """Get project root, supports local and Modal /app structure.
+
+    Returns the project root directory, which can be overridden via
+    the G1_PROJECT_ROOT environment variable for cloud deployment.
+    """
+    if custom := os.environ.get("G1_PROJECT_ROOT"):
+        return Path(custom)
+    # Default: parent of parent of this file (src/paths.py -> project root)
+    return Path(__file__).resolve().parent.parent
+
+
+def get_logs_dir() -> Path:
+    """Get logs directory (respects G1_LOGS_DIR env var).
+
+    Creates the directory if it doesn't exist.
+    """
+    if custom := os.environ.get("G1_LOGS_DIR"):  # noqa: SIM108
+        d = Path(custom)
+    else:
+        d = get_project_root() / "logs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def get_data_dir() -> Path:
+    """Get data/extractions directory (respects G1_DATA_DIR env var).
+
+    Creates the directory if it doesn't exist.
+    Used for storing experiment extractions and results.
+    """
+    if custom := os.environ.get("G1_DATA_DIR"):
+        d = Path(custom)
+    else:
+        d = get_project_root() / "extractions"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def get_experiments_dir() -> Path:
+    """Get experiments directory for legacy experiment data.
+
+    Creates the directory if it doesn't exist.
+    """
+    d = get_project_root() / "experiments"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# =============================================================================
+# Computed Path Constants (use functions above for dynamic resolution)
+# =============================================================================
+
+PROJECT_ROOT = get_project_root()
+LEGGED_GYM_ROOT = PROJECT_ROOT / "unitree_rl_gym"
+SCENARIOS_DIR = PROJECT_ROOT / "src" / "scenarios"
+EXPERIMENTS_DIR = PROJECT_ROOT / "experiments"
+
+# Robot config paths
+ROBOT_CONFIG_PATH = LEGGED_GYM_ROOT / "deploy/deploy_mujoco/configs/g1.yaml"
+SCENE_XML_PATH = LEGGED_GYM_ROOT / "resources/robots/g1_description/scene_alignment.xml"
+SCENE_DIR = LEGGED_GYM_ROOT / "resources/robots/g1_description"
+
+# API environment file
+ENV_PATH = PROJECT_ROOT / ".env"
+
+# Available scenes (use --scene flag to switch)
+SCENES = {
+    "barrels": "scene_barrels.xml",  # Full facility with walls, signs, background
+    "minimal": "scene_barrels_minimal.xml",  # Just robot, barrels, and charger
+    "alignment": "scene_alignment.xml",  # Original alignment scene
+}
+
+
+def get_scene_path(scene_name: str | None = None) -> Path:
+    """Get path to scene XML file.
+
+    Args:
+        scene_name: Scene name (e.g., 'minimal', 'barrels') or filename (e.g., 'scene_barrels.xml').
+                   Uses default if None.
+
+    Returns:
+        Full path to scene XML file.
+    """
+    if scene_name is None:
+        return SCENE_XML_PATH
+    # Check if it's a short name
+    if scene_name in SCENES:
+        return SCENE_DIR / SCENES[scene_name]
+    # Otherwise treat as filename
+    return SCENE_DIR / scene_name

--- a/src/scene_loader.py
+++ b/src/scene_loader.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import mujoco
 
+from src.paths import PROJECT_ROOT
+
 # Paths to menagerie models (relative to project root)
-PROJECT_ROOT = Path(__file__).parent.parent
 MENAGERIE_PATH = PROJECT_ROOT / "mujoco_menagerie"
 
 


### PR DESCRIPTION
## Summary
- Add `src/paths.py` with centralized path handling and env var overrides for Modal deployment
- Add `src/environment.py` with centralized env config dataclass
- Update config.py to re-export paths for backward compatibility
- Update inspect_eval modules to use centralized paths

## Environment Variables Added
- `G1_PROJECT_ROOT` - Override project root (for Modal `/app` structure)
- `G1_LOGS_DIR` - Override logs directory
- `G1_DATA_DIR` - Override data/extractions directory

## Test plan
- [x] All existing tests pass (`pytest tests/ -v`)
- [x] Lint checks pass (`ruff check src/ tests/ inspect_eval/`)
- [x] Import tests verify backward compatibility
- [x] SimulationState import works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable support for configuration (G1_PROJECT_ROOT, G1_LOGS_DIR, G1_DATA_DIR, G1_SCENARIO, etc.)
  * Introduced centralized configuration system with sensible defaults and lazy loading
  * Added path utility functions for flexible directory resolution

* **Refactor**
  * Centralized path and configuration management for improved maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->