### PR TITLE
Add trajectory recording to Inspect AI eval

### DIFF
--- a/inspect_eval/tools_native.py
+++ b/inspect_eval/tools_native.py
@@ -60,6 +60,8 @@ RECORD_VIDEO = os.environ.get("G1_RECORD_VIDEO", "false").lower() == "true"
 # Video dimensions (divisible by 16 for codec compatibility)
 VIDEO_WIDTH = int(os.environ.get("G1_VIDEO_WIDTH", "1280"))
 VIDEO_HEIGHT = int(os.environ.get("G1_VIDEO_HEIGHT", "720"))
+# Trajectory recording for browser playback (enabled via environment variable)
+RECORD_TRAJECTORY = os.environ.get("G1_RECORD_TRAJECTORY", "false").lower() == "true"
 # Headless mode - no viewer window (faster, especially with video recording)
 HEADLESS = os.environ.get("G1_HEADLESS", "false").lower() == "true"
 # Scenario selection (default: barrels)
@@ -81,6 +83,7 @@ def _get_state():
             record_video=RECORD_VIDEO,  # G1_RECORD_VIDEO=true to record
             video_width=VIDEO_WIDTH,
             video_height=VIDEO_HEIGHT,
+            record_trajectory=RECORD_TRAJECTORY,  # G1_RECORD_TRAJECTORY=true to record
             model_name=MODEL_NAME,
         )
     return _simulation_state
@@ -741,6 +744,14 @@ def end_mission():
             # Note: cleanup() is NOT called here - debrief tools need access to state
             # Cleanup happens when simulation is reset or at end of eval
 
+            # Save trajectory if recorded
+            trajectory_path = None
+            if state.has_trajectory:
+                timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+                trajectory_path = str(get_logs_dir() / f"trajectory_{timestamp}.json")
+                state.save_trajectory(trajectory_path)
+                _log(f"end_mission: trajectory saved ({state.trajectory_frame_count} frames)")
+
             end_data = json.dumps(
                 {
                     "status": "mission_ended",
@@ -754,6 +765,8 @@ def end_mission():
                     "goal_distance": round(result.goal_distance, 2),
                     "video_recorded": state.has_video,
                     "video_duration": round(state.video_duration, 1) if state.has_video else None,
+                    "trajectory_recorded": state.has_trajectory,
+                    "trajectory_path": trajectory_path,
                     "next_step": "Call request_debrief() to submit your mission report",
                 },
                 indent=2,

--- a/run_inspect_visual.py
+++ b/run_inspect_visual.py
@@ -223,6 +223,11 @@ Examples:
         help="Enable video recording",
     )
     parser.add_argument(
+        "--trajectory",
+        action="store_true",
+        help="Enable trajectory recording for browser playback",
+    )
+    parser.add_argument(
         "--headless",
         action="store_true",
         help="Run without MuJoCo viewer (faster)",
@@ -323,6 +328,8 @@ Examples:
     # Set environment variables based on flags
     if args.video:
         os.environ["G1_RECORD_VIDEO"] = "true"
+    if args.trajectory:
+        os.environ["G1_RECORD_TRAJECTORY"] = "true"
     if args.headless:
         os.environ["G1_HEADLESS"] = "true"
     if args.verbose:
@@ -358,6 +365,7 @@ Examples:
     print(f"  Judge: {args.judge}")
     print(f"  Timeout: 600s (robust_generate), {180}s per attempt (Inspect)")
     print(f"  Video: {args.video}")
+    print(f"  Trajectory: {args.trajectory}")
     print(f"  Headless: {args.headless}")
     print(f"  Verbose: {args.verbose}")
     print(f"  Debug: {args.debug}")


### PR DESCRIPTION
## Summary
- Add `--trajectory` flag to `run_inspect_visual.py` for enabling trajectory recording
- Wire up `G1_RECORD_TRAJECTORY` env var to pass `record_trajectory=True` to SimulationState
- Save trajectory JSON to logs directory when mission ends
- Include `trajectory_recorded` and `trajectory_path` in end_mission response

## Usage
```bash
venv/bin/mjpython run_inspect_visual.py --trajectory --headless
```

## Test plan
- [x] All 90 tests pass
- [x] Lint passes for tools_native.py
- [x] No new mypy errors
- [ ] Manual test with `--trajectory` flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trajectory recording capability that automatically saves trajectories to JSON files when enabled during simulations.
  * Added a new command-line flag to enable trajectory recording.
  * Mission end responses now include trajectory recording status and file path information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->