### PR TITLE
chore: point robotics shortcut at gemini-robotics-er-1.6-preview

### DIFF
--- a/local_runner.py
+++ b/local_runner.py
@@ -97,7 +97,7 @@ def run_experiment(
     # Model shortcuts (same as Modal)
     MODELS = {
         "gemini2.5": "google/gemini-2.5-pro",
-        "robotics": "google/gemini-robotics-er-1.5-preview",
+        "robotics": "google/gemini-robotics-er-1.6-preview",
         "claude": "anthropic/claude-3-5-sonnet-latest",
         "opus": "anthropic/claude-opus-4-5-20251101",
         "gpt4": "openai/gpt-4o",

--- a/modal/app.py
+++ b/modal/app.py
@@ -455,7 +455,7 @@ def run_experiment(
     # Model shortcuts
     MODELS = {
         "gemini2.5": "google/gemini-2.5-pro",
-        "robotics": "google/gemini-robotics-er-1.5-preview",
+        "robotics": "google/gemini-robotics-er-1.6-preview",
         "claude": "anthropic/claude-3-5-sonnet-latest",
         "opus": "anthropic/claude-opus-4-5-20251101",
         "gpt4": "openai/gpt-4o",

--- a/run_inspect_visual.py
+++ b/run_inspect_visual.py
@@ -341,7 +341,7 @@ def resolve_google_model(base_model: str) -> str:
         ValueError: If no Google credentials are configured
     """
     # Models only available via direct Gemini API (not on Vertex AI)
-    direct_api_only = {"gemini-robotics-er-1.5-preview"}
+    direct_api_only = {"gemini-robotics-er-1.6-preview"}
 
     if os.environ.get("GOOGLE_CLOUD_PROJECT") and base_model not in direct_api_only:
         return f"google/vertex/{base_model}"
@@ -372,7 +372,7 @@ GOOGLE_MODELS = {
     "gemini2.5": "gemini-2.5-pro",
     "gemini3": "gemini-3.1-pro-preview",
     "gemini3flash": "gemini-3.1-pro-preview",
-    "robotics": "gemini-robotics-er-1.5-preview",
+    "robotics": "gemini-robotics-er-1.6-preview",
 }
 
 OTHER_MODELS = {

--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ from src.paths import (  # noqa: F401
 # NOTE: Gemini 3 Pro is reserved for evaluation/orchestration and not included here
 GEMINI_MODELS = {
     "gemini2.5": "gemini-2.5-pro",  # Good thinking, general purpose
-    "robotics": "gemini-robotics-er-1.5-preview",  # Robotics-specific - spatial reasoning, trajectory planning
+    "robotics": "gemini-robotics-er-1.6-preview",  # Robotics-specific - spatial reasoning, trajectory planning
 }
 GEMINI_MODEL = GEMINI_MODELS["robotics"]  # Default model
 


### PR DESCRIPTION
## What

Point the `robotics` model shortcut at **`gemini-robotics-er-1.6-preview`** across all runtime model pointers.

## Why

`gemini-robotics-er-1.5-preview` (the model the Feb competition runs used) was **shut down 2026-04-30** and replaced by `gemini-robotics-er-1.6-preview` (adds instrument reading + improved spatial/physical reasoning). The old ID now 404s everywhere.

## Changes

Updated the 5 live pointers:
- `run_inspect_visual.py` — `GOOGLE_MODELS["robotics"]` + the `direct_api_only` set
- `local_runner.py`, `modal/app.py` — `MODELS["robotics"]`
- `src/config.py` — `GEMINI_MODELS["robotics"]`

## Still Vertex-incompatible

Live-probed `ipu` project on Vertex (us-central1) — `1.5-preview`, `1.5`, and `1.6-preview` all return 404. Robotics-ER remains **direct Gemini API only**, so it needs `GEMINI_API_KEY` (AI Studio), not Vertex ADC. The `direct_api_only` guard preserves that behaviour.

## Deliberately left as-is

Historical run data keeps the `1.5-preview` name — those are genuine 1.5-preview runs:
- `gcp/frontend/assets/trajectory_*.json` (recorded transcripts)
- viewer color maps (`trajectoryStore.js`, `trajectory.ts`, `FilterPanel.tsx`)
- `inspect_eval/README.md` example paths

## Not verified

No live smoke run — `.env` currently has no `GEMINI_API_KEY`, so the 1.6 path is unexercised. Confirmed offline: pointers updated, ruff/format clean, files parse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the robotics model shortcut to the latest available preview version across all system components, including the local runner, modal application interface, visual inspection tool, and core configuration files. When users select the robotics model, the system now automatically uses the updated model identifier, ensuring consistent and current behavior throughout the application environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->